### PR TITLE
chore: correct creation of URL_PATH

### DIFF
--- a/scripts/get-depended-repos.sh
+++ b/scripts/get-depended-repos.sh
@@ -25,7 +25,7 @@ do
   REPO_PATH=src/content/$URL_PATH
   _message "Cloning $ORGANIZATION/$REPO_NAME.."
   git clone -n https://$TOKEN@github.com/$ORGANIZATION/$REPO_NAME /tmp/$REPO_NAME
-  mkdir -p src/content/ # make sure subfolder exists
+  mkdir -p $REPO_PATH # make sure subfolder(s) exists
   mv /tmp/$REPO_NAME$SRC_DIR $REPO_PATH
   rm -rf /tmp/$REPO_NAME # clean it
   echo


### PR DESCRIPTION
At the moment if we have more then one level in URL_PATH variable defined inside dependencies_repos.csv then pipeline will fail due to inappropriate handling of this part by the dependencies repo script.