### PR TITLE
chore: lint commit messages for any pull request

### DIFF
--- a/CI-pipeline.yml
+++ b/CI-pipeline.yml
@@ -1,0 +1,24 @@
+name: Ockam-website-$(Date:yyyyMMdd).$(Rev:r)
+
+pr:
+  branches:
+    include:
+    - '*'  # enabled PR trigger for all branches
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+
+steps:
+- task: NodeTool@0
+  displayName: 'Install Node.js'
+  inputs:
+    versionSpec: '12.x'
+
+- bash: |
+    if [ ! -z "$SYSTEM_PULLREQUEST_TARGETBRANCH" ]; then
+      npx commitlint --from $(git rev-parse origin/$SYSTEM_PULLREQUEST_TARGETBRANCH) --to HEAD --verbose
+    else
+      npx commitlint --from HEAD~1 --to HEAD --verbose
+    fi
+  displayName: 'Lint Commit Messages'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,14 +23,6 @@ steps:
     versionSpec: '12.x'
 
 - bash: |
-    if [ ! -z "$SYSTEM_PULLREQUEST_TARGETBRANCH" ]; then
-      npx commitlint --from $(git rev-parse origin/$SYSTEM_PULLREQUEST_TARGETBRANCH) --to HEAD --verbose
-    else
-      npx commitlint --from HEAD~1 --to HEAD --verbose
-    fi
-  displayName: 'Lint Commit Messages'
-
-- bash: |
     set -ex
     ./scripts/get-depended-repos.sh
   displayName: 'Checkout depended repositories'
@@ -74,7 +66,7 @@ steps:
     set -ex
     rm -f ./public/*.map
     rm -f ./public/webpack.stats.json
-  displayName: 'Remove vulnerabilities'
+  displayName: 'Remove sourcemaps and webpack stats'
 
 - bash: |
     set -ex
@@ -138,5 +130,5 @@ steps:
       --name $(CDN_ENDPOINT) \
       --profile-name $(CDN_PROFILE) \
       --content-paths '/*'
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master')) # only for PRODUCTION
+  condition: and( succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master') ) # only for PRODUCTION
   displayName: "Purge CDN"


### PR DESCRIPTION
There is a separate pipeline file because this linting is actually continuous integrations process and the main pipeline is continuous delivery. Also, they react on different triggers, `azure-pipelines` on commit/merge/etc. to master, stage and develop branch, whereas `CI-pipeline` on linting which is happening at PR's event only.