### PR TITLE
content: add mgt levels to role guide

### DIFF
--- a/src/content/learn/guides/contributions/ockam_c_code_standard.md
+++ b/src/content/learn/guides/contributions/ockam_c_code_standard.md
@@ -69,7 +69,7 @@ uint32 my_weight_lbs;
 
 ### Structure Names
 
-* Use underbars ('_') to separate name components
+* Use underbars ('_') to separate name components.
 * When declaring variables in structures, declare them organized by use in a manner to
 attempt to minimize memory wastage because of compiler alignment issues, then by
 size, and then by alphabetical order. E.g, don't use ``int a; char *b; int c; char *d''; use
@@ -169,7 +169,9 @@ enum { STATE_ERR, STATE_OPEN, STATE_RUNNING, STATE_DYING};
 
 ## Formatting
 
-### Brace Placement
+### Braces
+
+**Placement**
 
 Of the three major brace placement strategies one is recommended:
 
@@ -182,11 +184,11 @@ if (condition) {
 }
 ```
 
-### When Braces are Needed
+**When Braces are Needed**
 
 All if, while and do statements must either have braces or be on a single line.
 
-#### Always Uses Braces Form
+**Always Uses Braces Form**
 
 All if, while and do statements require braces even if there is only a single statement within the
 braces.
@@ -202,7 +204,7 @@ if (1 == somevalue) {
 It ensures that when someone adds a line of code later there are already braces and they don't
 forget. It provides a more consistent look. This doesn't affect execution speed. It's easy to do.
 
-#### One Line Form
+**One Line Form**
 
 ```c
 if (1 == somevalue) somevalue = 2;
@@ -212,7 +214,7 @@ if (1 == somevalue) somevalue = 2;
 
 It provides safety when adding new lines while maintaining a compact readable form.
 
-### Add Comments to Closing Braces
+**Add Comments to Closing Braces**
 
 Adding a comment to closing braces can help when you are reading code because you don't
 have to find the begin brace to know what is going on.
@@ -459,12 +461,12 @@ the first or last character of a header guard.
 
 ## Macros
 
-### Mostly Don’t Use Them
+**Mostly Don’t Use Them**
 
 Macros can cause readability problems and can be difficult to debug. Avoid using macros
 unless there’s a remarkably compelling reason to do so.
 
-### Prefer Inline Functions
+**Prefer Inline Functions**
 
 In C, macros are not needed for code efficiency. Use inlines. While macros for small functions
 aren’t a travesty, inline functions should be preferred.
@@ -483,7 +485,7 @@ inline int max(int x, int y) {
 }
 ```
 
-### Be Careful of Side Effects
+**Be Careful of Side Effects**
 
 Macros should be used with caution because of the potential for error when invoked with an
 expression that has side effects.
@@ -492,7 +494,7 @@ expression that has side effects.
 MAX(f(x),z++);
 ```
 
-### Always Wrap the Expression in Parenthesis
+**Always Wrap the Expression in Parenthesis**
 
 When putting expressions in macros always wrap the expression in parenthesis to avoid
 potential communitive operation ambiguity.
@@ -507,7 +509,7 @@ must be written as
 #define ADD(x,y) ((x) + (y))
 ```
 
-### Make Macro Names Unique
+**Make Macro Names Unique**
 
 Like global variables macros can conflict with macros from other packages.
 
@@ -620,7 +622,7 @@ increase as the human memory of what's going on in the latter piece of code begi
 
 ## Documentation
 
-### Comments Should Tell a Story
+**Comments Should Tell a Story**
 
 Consider your comments a story describing the system. Expect your comments to be extracted
 by a robot and formed into a man page. Class comments are one part of the story, method
@@ -628,13 +630,13 @@ signature comments are another part of the story, method arguments another part,
 implementation yet another part. All these parts should weave together and inform someone
 else at another point of time just exactly what you did and why.
 
-### Document Decisions
+**Document Decisions**
 
 Comments should document decisions. At every point where you had a choice of what to do
 place a comment describing which choice you made and why. Archeologists will find this the
 most useful information.
 
-### Use Headers
+**Use Headers**
 
 Use ​Doxygen​.
 
@@ -642,19 +644,19 @@ These headers are structured in such a way as they can be parsed and extracted. 
 useless like normal headers. So take time to fill them out. If you do it right once no more
 documentation may be necessary.
 
-### Comment Layout
+**Comment Layout**
 
 Each part of the project has a specific comment layout. ​Doxygen​ has the recommended format
 for the comment layouts.
 
-### Make Gotchas Explicit
+**Make Gotchas Explicit**
 
 Explicitly comment variables changed out of the normal control flow or other code likely to break
 during maintenance. Embedded keywords are used to point out issues and potential problems.
 Consider a robot will parse your comments looking for keywords, stripping them out, and making
 a report so people can make a special effort where needed.
 
-#### Gotcha Keywords
+**Gotcha Keywords**
 
 * @author:
 specifies the author of the module
@@ -682,7 +684,7 @@ what remains to be done
 report a bug found in the piece of code
 
 
-#### Gotcha Formatting
+**Gotcha Formatting**
 
 * Make the gotcha keyword the first symbol in the comment.
 * Comments may consist of multiple lines, but the first line should be a self-containing,
@@ -693,13 +695,13 @@ and by whom it was added. Often gotchas stick around longer than they should.
 Embedding date information allows other programmer to make this decision. Embedding
 who information lets us know who to ask.
 
-### Commenting function declarations
+**Commenting function declarations**
 
 Functions headers should be in the file where they are declared. This means that most likely the
 functions will have a header in the .h file. However, functions like main() with no explicit
 prototype declaration in the .h file, should have a header in the .c file.
 
-### Include Statement Documentation
+**Include Statement Documentation**
 
 Include statements should be documented, telling the user why a particular file was included.
 

--- a/src/content/learn/guides/team/engineering_levels.md
+++ b/src/content/learn/guides/team/engineering_levels.md
@@ -54,12 +54,12 @@ At Ockam we [value our High Performance Team](https://www.ockam.io/learn/guides/
       </strong>
     </td>
     <td>
-    <ul>
-      <li> Has an engineering and programming foundation based upon several years of study.</li>
-      <li> Expected to spend the majority of time learning about code and development best practices.</li>
-      <li> Understands scope of small features.</li>
-      <li> Has a basic understanding of what all components in their product are.</li>
-    </ul>
+      <ul>
+          <li> Has an engineering and programming foundation based upon several years of study.</li>
+          <li> Expected to spend the majority of time learning about code and development best practices.</li>
+          <li> Understands scope of small features.</li>
+          <li> Has a basic understanding of what all components in their product are.</li>
+      </ul>
     </td>
     <td>
       <ul>
@@ -74,7 +74,7 @@ At Ockam we [value our High Performance Team](https://www.ockam.io/learn/guides/
     <td>
       <ul>
           <li> Has in-depth understanding of development best practices.</li>
-          <li> Highly attuned to various coding styles used in the open source community and his hyper focused on writing simple, well designed, human readable code.</li>
+          <li> Highly attuned to various coding styles used in the open source community and his hyper-focused on writing simple, well designed, human readable code.</li>
           <li> Has mastered the tools needed to debug and diagnose issues in any type of environment.</li>
           <li> Understands the scope and relationships of large features and production stack for their area.</li>
           <li> Has subject matter expertise in several components.</li>
@@ -84,17 +84,17 @@ At Ockam we [value our High Performance Team](https://www.ockam.io/learn/guides/
     <td>
       <ul>
           <li> Has mastered development best practices.</li>
-          <li> Understands the limits of our tools and when a problem that exceeds those limits deserves the effort of producing a new tool.</li>
+          <li> Understands the limits of our tools, and when a problem that exceeds those limits, produces a new tool.</li>
           <li> Understands the scope and relationships of large features and production stack for their area.</li>
           <li> Has subject matter expertise on multiple components across multiple products.</li>
           <li> Has a strong understanding of all products relevant to their own areas of expertise.</li>
       </ul>
     </td>
     <td>
-    <ul>
-        <li> Has deep knowledge of the entire system, and can jump into code in any component and fire fight and contribute.</li>
-        <li> Makes decisions on product direction and internals based on deep subject matter knowledge.</li>
-    </ul>
+      <ul>
+          <li> Has deep knowledge of the entire system, and can jump into code in any component, fire-fight, and contribute.</li>
+          <li> Makes decisions on product direction and internals based on deep subject matter knowledge.</li>
+      </ul>
     </td>
   </tr>
 
@@ -116,22 +116,21 @@ At Ockam we [value our High Performance Team](https://www.ockam.io/learn/guides/
         <ul>
           <li> Performs standard programming tasks.</li>
           <li> Contributes to functional specifications and participates in code reviews.</li>
-          <li> Writes documentation and examples that ships along with their code.</li>
+          <li> Writes documentation and examples that ship along with their code.</li>
           <li> Writes and executes sophisticated test plans.</li>
-          <li> Has the network and ability to recruit ‘A player’ engineers at their own level.</li>
-          <li> Can accurately forecast and deliver a mile (2 week) of deliverables.</li>
+          <li> Has the network, and ability, to recruit ‘A player’ engineers at their own level.</li>
+          <li> Can accurately forecast and deliver a mile (2 week) deliverables.</li>
         </ul>
     </td>
     <td>
       <ul>
           <li> Performs complex programming tasks.</li>
-          <li> Participates in code reviews and can sign off features.</li>
           <li> Can write functional specifications for features.</li>
-          <li> Can sign off on test plans.</li>
+          <li> Can sign off on test plans and code reviews.</li>
           <li> Participates in requirement building with architects.</li>
-          <li> Gathers feedback and ‘pulse’ from our open source community.</li>
-          <li> Has the network and has demonstrated the ability to recruit engineers at or above their level.</li>
-          <li> Can accurately forecast and deliver Race (8 weeks) of OKRs.</li>
+          <li> Gathers feedback and ‘pulse’ from Ockam's open source community.</li>
+          <li> Has the network, and has demonstrated the ability, to recruit engineers above their level.</li>
+          <li> Can accurately forecast and deliver Race (8 weeks) OKRs.</li>
       </ul>
     </td>
     <td>
@@ -139,15 +138,15 @@ At Ockam we [value our High Performance Team](https://www.ockam.io/learn/guides/
           <li> Performs expert programming tasks.</li>
           <li> Handles large-scale technical debt and refactoring.</li>
           <li> Shapes coding methodologies, style, DX, and best practices across wide areas of the Ockam code base.</li>
-          <li> Participates in code reviews and can sign-off on large features.</li>
+          <li> Leads code reviews and can sign-off on large features.</li>
           <li> Participates in requirements gathering with direct contact with customers.</li>
-          <li> Has the ability to recruit other Architects in adjacent areas of the team where they lack technical expertise.</li>
-          <li> Can accurately forecast and deliver Campaign (8 months) of OKRs.</li>
+          <li> Has the ability to recruit other Architects in areas where they lack technical expertise.</li>
+          <li> Can accurately forecast and deliver Campaign (8 months) OKRs.</li>
       </ul>
     </td>
     <td>
       <ul>
-          <li>  Sets product direction and has ownership over large components.</li>
+          <li> Sets product direction and has ownership over large components.</li>
           <li> Thinks both strategically and tactically, keeping in mind both technical goals and company business/GTM goals.</li>
           <li> Understands trade offs of OKRs across the entire company.</li>
           <li> Contributes to and shapes company-wide Horizon scale OKRs.</li>
@@ -194,7 +193,7 @@ At Ockam we [value our High Performance Team](https://www.ockam.io/learn/guides/
     <td>
       <ul>
           <li> Builds strong relationships industry wide.</li>
-          <li> Understands the merits and faults with multiple points of view and can drive a process to conclusions in a timely and respectful manner.</li>
+          <li> Understands the merits and faults of multiple points of view and can drive a process to conclusions in a timely and respectful manner.</li>
       </ul>
     </td>
   </tr>
@@ -257,6 +256,169 @@ At Ockam we [value our High Performance Team](https://www.ockam.io/learn/guides/
 </table>
 </div>
 
+## Engineering - Management
+
+<div style="overflow-x: auto;">
+<table>
+  <tr>
+    <th> </th>
+    <th>Program Manager </th>
+    <th>Director </th>
+    <th>CTO </th>
+  </tr>
+
+  <tr>
+    <td>
+        <strong>
+            Level
+        </strong>
+    </td>
+    <td>5 </td>
+    <td>6 - 7 </td>
+    <td>8 </td>
+  </tr>
+
+  <tr>
+    <td>
+        <strong>
+           Responsibility abstraction
+        </strong>
+    </td>
+    <td>“Projects” </td>
+    <td>“Teams” </td>
+    <td>“Product” </td>
+  </tr>
+
+  <tr>
+    <td>
+      <strong>
+        Existing knowledge
+      </strong>
+    </td>
+    <td>
+      <ul>
+          <li> A senior engineer, who in addition, has very broad knowledge of the entire product, and can help with any component, or type of issues.</li>
+          <li> Strong awareness of the state of the product and team at all times.</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+          <li> A great lead engineer, who knows how to allocate resources among projects and understands how company priorities map to their tasks.</li>
+          <li> Has subject matter expertise on multiple components across multiple products.</li>
+          <li> Recognizes strengths in others and empowers them to make decisions.</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+          <li> Knows the entire product, how customers use it, what they want, and where it should go.</li>
+          <li> Makes decisions on product specifications.</li>
+      </ul>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <strong>
+        Complexity of role
+      </strong>
+    </td>
+    <td>
+      <ul>
+          <li> Contributes to code at a Senior Engineer level.</li>
+          <li> Prioritizes tasks and issues across projects and people.</li>
+          <li> An expert firefighter who is often called in to make things right.</li>
+          <li> Has the network and has demonstrated the ability to recruit engineers at or above their level.</li>
+          <li> Helps build Race (8 weeks) OKRs.</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+          <li> Balances strategic and tactical goals, distributes work across the team.</li>
+          <li> Manages large-scale technical debt and refactoring.</li>
+          <li> Shapes code methodologies, style, and DX.</li>
+          <li> Participates in code reviews and can sign-off on large features.</li>
+          <li> Has the ability to recruit Architects outside of their technical expertise.</li>
+          <li> Helps to build Campaign (8 months) OKRs.</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+          <li> Sets product direction.</li>
+          <li> Thinks both strategically and tactically, keeping in mind both technical goals and company business/GTM goals.</li>
+          <li> Understands trade offs of OKRs across the entire company.</li>
+          <li> Can influence customer and partners product roadmaps.</li>
+          <li> Builds OKRs at the Race, Campaign and Horizon scale.</li>
+      </ul>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <strong>
+        Professional Character
+      </strong>
+    </td>
+    <td>
+      <ul>
+          <li> Delivers feedback across the entire team in a constructive manner.</li>
+          <li> Provides guidance to internal and external engineers.</li>
+          <li> Works well with other technical leads, incorporating feedback as needed.</li>
+          <li> Helps focus discussion in their team on the most important aspects that align with OKRs.</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+          <li> An approachable mentor who can work with individuals that have stronger technical expertise than them in many areas.</li>
+          <li> Constructively challenges assumptions.</li>
+          <li> Guides engineers to correct solutions while encouraging collaboration.</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+          <li> Builds strong relationships industry wide.</li>
+          <li> Understands the merits and faults in multiple points of view and can drive a process to conclusions in a timely and respectful manner.</li>
+      </ul>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <strong>
+        Independence
+      </strong>
+    </td>
+    <td>
+      <ul>
+          <li> Leads projects and/or small teams.</li>
+          <li> Participates in and supports initiatives outside of main area of responsibility.</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+          <li> Manages multiple teams and projects.</li>
+          <li> Responsible for team retention and hiring.</li>
+      </ul>
+    </td>
+    <td>
+      <ul>
+          <li> Is a great leader, and sets direction for the product.</li>
+          <li> Understands vision / mission, and drives it forward.</li>
+      </ul>
+    </td>
+  </tr>
+
+  <tr>
+    <td>
+      <strong>
+        Personal Growth Plan Focus
+      </strong>
+      </td>
+    <td>“Teaching”</td>
+    <td>“Empowering”</td>
+    <td>“Industry influencer / Luminary”</td>
+  </tr>
+</table>
+</div>
 
 **Note:**
 
@@ -267,13 +429,21 @@ At Ockam we [value our High Performance Team](https://www.ockam.io/learn/guides/
 
 ## Anti-Patterns
 
-**Levels 1-2:** Poor code quality. Not self-motivated; needs someone to tell them what to do next. Constantly veers into the weeds. More inclined to blame-complain than roll up sleeves. General helplessness. Disregards team process.
+**Levels 1-2:**
 
-**Levels 3-4:** Disappears into projects that don’t matter to the business. Fails to identify or communicate big roadblocks. Us-vs-them attitude. Continually underestimates timelines. Doesn’t take operational excellence seriously. Solutions are more complicated than necessary.
+Poor code quality. Not self-motivated; needs someone to tell them what to do next. Constantly veers into the weeds. More inclined to blame-complain than roll up sleeves. General helplessness. Disregards team process.
 
-**Levels 5:** Arrogant jerk. Doesn’t delegate. Always says "yes" and suffers burn-out. Jumps into execution without careful consideration. Lets details slip through the cracks. Fails to raise awareness of projects at risk or people-problems. Doesn’t follow new technologies or industry trends. Thinks that some work is ‘beneath them’.
+**Levels 3-4:**
 
-**Levels 6-8:** Over-emphasis on scaling or high availability far beyond business needs. Spends too much time chasing the newest "shiny" technology simply to satisfy ego. Doesn’t collaborate or ask questions. Condescending. Has a “pet” agenda. Pisses off senior leadership.
+Disappears into projects that don’t matter to the business. Fails to identify or communicate big roadblocks. Us-vs-them attitude. Continually underestimates timelines. Doesn’t take operational excellence seriously. Solutions are more complicated than necessary.
+
+**Levels 5:**
+
+Arrogant jerk. Doesn’t delegate. Always says "yes" and suffers burn-out. Jumps into execution without careful consideration. Lets details slip through the cracks. Fails to raise awareness of projects at risk or people-problems. Doesn’t follow new technologies or industry trends. Thinks that some work is ‘beneath them’.
+
+**Levels 6-8:**
+
+Over-emphasis on scaling or high availability far beyond business needs. Spends too much time chasing the newest "shiny" technology simply to satisfy ego. Doesn’t collaborate or ask questions. Condescending. Has a “pet” agenda. Pisses off senior leadership.
 
 ## References
 


### PR DESCRIPTION
This commit adds an engineering 'management track' to our role guide.

It also attempts to clean up our C Coding guide on a quick pass through it.