### PR TITLE
content: fix rust how-to 01 to 02 link

### DIFF
--- a/src/content/learn/how-to-guides/rust/01-node/README.md
+++ b/src/content/learn/how-to-guides/rust/01-node/README.md
@@ -63,4 +63,4 @@ This will download various dependencies, compile and then run our code. When it
 runs, you'll see log output that shows the node starting and then
 immediately shutting down.
 
-<span><b>Next:</b> <a href=" /learn/how-to-guides/rust/02-worker">02. Create an Ockam worker</a></span>
+<span><b>Next:</b> <a href="/learn/how-to-guides/rust/02-worker">02. Create an Ockam worker</a></span>


### PR DESCRIPTION
I just found this broken link while following the how-to guide and thought to PR the fix.