### PR TITLE
docs: consistent Rust naming

### DIFF
--- a/src/content/learn/how-to-guides/contributing/ockam_rust_code_standard.md
+++ b/src/content/learn/how-to-guides/contributing/ockam_rust_code_standard.md
@@ -6,7 +6,7 @@ order: 5
 
 This guide will help us keep the style in our Rust Library consistent.
 
-This guide builds on the normal rust style guide [here](https://doc.rust-lang.org/1.0.0/style/)
+This guide builds on the normal Rust style guide [here](https://doc.rust-lang.org/1.0.0/style/)
 
 ## Names
 


### PR DESCRIPTION
I noticed one lowercase use of "rust" so I changed it to "Rust" for consistency.