### PR TITLE
fix: gatsby needs istrue in one blog post header

### DIFF
--- a/src/content/learn/blog/high_performance_team.md
+++ b/src/content/learn/blog/high_performance_team.md
@@ -5,6 +5,7 @@ description: "High Performance Teams don't happen by accident. We've got a playb
 metaTitle: "One of Ockam's core values is that we are a High Performance Team. Just like open source software builds on top of the shoulders of giants, so do my ideas around team building. Specifically about building a High Performance Team"
 author: "Matthew Gregory"
 authorAvatar: ./assets/matthew_gregory-1.png
+isFeature: true
 ---
 
 <div id="presentation">

--- a/src/content/learn/blog/oktane_2021_trust.md
+++ b/src/content/learn/blog/oktane_2021_trust.md
@@ -6,7 +6,7 @@ metaTitle: "Replay from Okta Oktane21. A builders guide to Trust in autonomous c
 author: "Matthew Gregory"
 authorAvatar: ./assets/matthew_gregory-1.png
 isHomepageFeatured: true
-homepageFeaturedOrder: 1
+homepageFeaturedOrder: 3
 ---
 
 # End-to-end encryption and mutual authentication between cloud and edge apps

--- a/src/content/learn/blog/series_a.md
+++ b/src/content/learn/blog/series_a.md
@@ -6,7 +6,7 @@ metaTitle: "Ockam builds open-source developer-first tools for mutual authentica
 author: "Matthew Gregory"
 authorAvatar: ./assets/matthew_gregory-1.png
 isHomepageFeatured: true
-homepageFeaturedOrder: 3
+homepageFeaturedOrder: 1
 ---
 
 *Ockam builds open-source developer-first tools for mutual authentication and end-to-end encrypted messaging between distributed applications, in any environment, anywhere… Trust Data-in-Motion.*


### PR DESCRIPTION
To fix an error in Gatsby, I added `isFeature: true` to the meta data of one of the blogs. `isFeature` is not used in our website, from what I can tell - however Gatsby seems to expect it, and the build breaks without it.